### PR TITLE
E-cars.hu hírdetés blokkolása

### DIFF
--- a/hufilter-abp.txt
+++ b/hufilter-abp.txt
@@ -358,6 +358,7 @@ divany.hu##iframe
 donna.hu##[class*="banner"]
 donna.hu##[id*="banner"]
 duen.hu##[id*="banner"]
+e-cars.hu##DIV[class="td-a-rec td-a-rec-id-content_top  tdi_62 td_block_template_1"]
 ecoline.hu##[class^="ads"]
 ecoline.hu##[id*="_ad"]
 eduline.hu##[class*="ad_"]

--- a/hufilter-adguard.txt
+++ b/hufilter-adguard.txt
@@ -358,6 +358,7 @@ divany.hu##iframe
 donna.hu##[class*="banner"]
 donna.hu##[id*="banner"]
 duen.hu##[id*="banner"]
+e-cars.hu##DIV[class="td-a-rec td-a-rec-id-content_top  tdi_62 td_block_template_1"]
 ecoline.hu##[class^="ads"]
 ecoline.hu##[id*="_ad"]
 eduline.hu##[class*="ad_"]

--- a/hufilter-ublock.txt
+++ b/hufilter-ublock.txt
@@ -358,6 +358,7 @@ divany.hu##iframe
 donna.hu##[class*="banner"]
 donna.hu##[id*="banner"]
 duen.hu##[id*="banner"]
+e-cars.hu##DIV[class="td-a-rec td-a-rec-id-content_top  tdi_62 td_block_template_1"]
 ecoline.hu##[class^="ads"]
 ecoline.hu##[id*="_ad"]
 eduline.hu##[class*="ad_"]

--- a/hufilter.txt
+++ b/hufilter.txt
@@ -358,6 +358,7 @@ divany.hu##iframe
 donna.hu##[class*="banner"]
 donna.hu##[id*="banner"]
 duen.hu##[id*="banner"]
+e-cars.hu##DIV[class="td-a-rec td-a-rec-id-content_top  tdi_62 td_block_template_1"]
 ecoline.hu##[class^="ads"]
 ecoline.hu##[id*="_ad"]
 eduline.hu##[class*="ad_"]


### PR DESCRIPTION
Pld. https://e-cars.hu/2023/05/09/mar-1958-ban-is-volt-napenergiaval-hajtott-elektromos-auto/